### PR TITLE
Move provider imports out of lib/registry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,20 @@ At the moment, ToolHub implements hubs for the OpenAI chat completions and assis
 
 ```python
 from toolhub.lib import auth
-from toolhub.openai import openai_assistant_hub
 from toolhub.lib import registry
+from toolhub.integrations.rapidapi import provider as rapidapi_provider
+from toolhub.openai import openai_assistant_hub
 
 # A collection of the tools that we want the registry to support.
 # For example, this registry supports:
 # 1. All Alpha Vantage endpoints, and
 # 2. The Yelp business search endpoint.
-registry_ = registry.Registry.standard(
-	filter_rapidapi_api_hostnames=["https://alpha-vantage12.p.rapidapi.com/"],
-  filter_rapidapi_endpoint_urls=["[https://yelp-reviews.p.rapidapi.com/business-search](https://yelp-reviews.p.rapidapi.com/business-search)"],
-)
+registry_ = registry.Registry([
+    rapidapi_provider.Provider.standard(
+	    filter_rapidapi_api_hostnames=["https://alpha-vantage12.p.rapidapi.com/"],
+        filter_rapidapi_endpoint_urls=["[https://yelp-reviews.p.rapidapi.com/business-search](https://yelp-reviews.p.rapidapi.com/business-search)"],
+    )
+])
 
 auth_ctx = auth.AuthContext(rapidapi=auth.RapidApiAuthContext(rapidapi_key=<YOUR_KEY>))
 
@@ -94,10 +97,11 @@ hub_ = openai_assistant_hub.OpenAIAssistantHub(
     from toolhub.lib import auth
     from toolhub.lib import registry
     from toolhub.openai import openai_assistant_hub
+    from toolhub.standard_providers import random_provider
     
     hub_ = openai_assistant_hub.OpenAIAssistantHub(
-      registry_=registry.Registry.standard(filter_collections=['random']),
-    	auth_ctx=auth.AuthContext(),
+        registry_=registry.Registry([random_provider.Provider()]),
+        auth_ctx=auth.AuthContext(),
     )
     ```
     
@@ -112,6 +116,7 @@ For now, our OSS implementation only supports crunchbase as an example. To use c
 ```python
 from toolhub.lib import auth
 from toolhub.lib import registry
+from toolhub.integrations.openapi import provider as openapi_provider
 from toolhub.openai import openai_assistant_hub
 
 auth_ctx = auth.AuthContext(
@@ -123,7 +128,10 @@ auth_ctx = auth.AuthContext(
 )
 
 hub_ = openai_assistant_hub.OpenAIAssistantHub(
-  registry_=registry.Registry.standard(filter_collections='crunchbase'),
+    registry_=registry.Registry(
+        [openapi_provider.Provider.standard()],
+        filter_collections='crunchbase',
+    ),
 	auth_ctx=auth_ctx,
 )
 ```
@@ -248,7 +256,7 @@ We support adding any API defined in the OpenAPI format. Follow these instructio
       simple_api_loader,
       custom_api_loader,
     ])
-    registry_ = registry.Registry.standard(openapi=openapi_provider)
+    registry_ = registry.Registry([openapi_provider])
     ```
     
 6. For contributions, add the new API to `toolhub.integrations.openapi.provider::Provider.standard`.

--- a/toolhub/demo/call_tools.py
+++ b/toolhub/demo/call_tools.py
@@ -4,6 +4,9 @@ from openai.types.beta.threads.required_action_function_tool_call import (
 )
 
 from toolhub.demo import utils
+from toolhub.integrations.openapi import provider as openapi_provider
+from toolhub.integrations.rapidapi import provider as rapidapi_provider
+from toolhub.standard_providers import random_provider
 from toolhub.lib import hub
 from toolhub.lib import registry
 from toolhub.openai import openai_assistant_hub
@@ -12,18 +15,24 @@ from toolhub.openai import openai_assistant_hub
 if __name__ == "__main__":
     # NOTE: specify credentials in toolhub/demo/utils.py.
     hub_ = openai_assistant_hub.OpenAIAssistantHub(
-        registry_=registry.Registry.standard(
+        registry_=registry.Registry(
+            [
+                random_provider.Provider(),
+                openapi_provider.Provider.standard(),
+                rapidapi_provider.Provider.standard(
+                    filter_rapidapi_api_hostnames=[
+                        "https://currency-converter18.p.rapidapi.com"
+                    ],
+                    filter_rapidapi_endpoint_urls=[
+                        "https://currency-converter18.p.rapidapi.com/api/v1/convert"
+                    ],
+                ),
+            ],
             filter_collections=[
                 "random",
                 "crunchbase",
                 "Financial.currency_converter_v2",
             ],
-            # filter_rapidapi_api_hostnames=[
-            #     "https://currency-converter18.p.rapidapi.com"
-            # ],
-            # filter_rapidapi_endpoint_urls=[
-            #     "https://currency-converter18.p.rapidapi.com/api/v1/convert"
-            # ],
         )
     )
     tool_calls = [

--- a/toolhub/demo/utils.py
+++ b/toolhub/demo/utils.py
@@ -3,6 +3,9 @@ import openai
 from toolhub.config import settings
 from toolhub.lib import auth
 from toolhub.lib import registry
+from toolhub.integrations.openapi import provider as openapi_provider
+from toolhub.integrations.rapidapi import provider as rapidapi_provider
+from toolhub.standard_providers import random_provider
 
 
 def openai_client() -> openai.OpenAI:
@@ -20,14 +23,27 @@ def registry_(
     rapidapi_api_hostnames: str | None,
     rapidapi_endpoint_urls: str | None,
 ) -> registry.Registry:
-    return registry.Registry.standard(
-        filter_collections=(collections.split(",") if collections else None),
-        filter_rapidapi_api_hostnames=(
-            rapidapi_api_hostnames.split(",") if rapidapi_api_hostnames else None
-        ),
-        filter_rapidapi_endpoint_urls=(
-            rapidapi_endpoint_urls.split(",") if rapidapi_endpoint_urls else None
-        ),
+    return registry.Registry(
+        [
+            *(
+                [random_provider.Provider(), openapi_provider.Provider.standard()]
+                if not (rapidapi_api_hostnames or rapidapi_endpoint_urls)
+                else []
+            ),
+            rapidapi_provider.Provider.standard(
+                filter_rapidapi_api_hostnames=(
+                    rapidapi_api_hostnames.split(",")
+                    if rapidapi_api_hostnames
+                    else None
+                ),
+                filter_rapidapi_endpoint_urls=(
+                    rapidapi_endpoint_urls.split(",")
+                    if rapidapi_endpoint_urls
+                    else None
+                ),
+            ),
+        ],
+        filter_collections=collections.split(",") if collections else None,
     )
 
 

--- a/toolhub/integrations/openapi/client.py
+++ b/toolhub/integrations/openapi/client.py
@@ -37,7 +37,7 @@ def request(
         method=method,
         headers=headers,
         cookies={},
-        timeout=settings.openapi.timeout_s,
+        timeout=settings.get("openapi", {}).get("timeout_s", 5.0),
         params=params,
         url=url,
     )

--- a/toolhub/integrations/rapidapi/provider.py
+++ b/toolhub/integrations/rapidapi/provider.py
@@ -1,14 +1,86 @@
 from __future__ import annotations
 
+from collections import defaultdict
+import re
+
 from toolhub.lib import function
 from toolhub.lib import provider
 
+from toolhub.integrations.rapidapi import function as rapidapi_function
 from toolhub.integrations.rapidapi import loader
+from toolhub.integrations.rapidapi import utils as rapidapi_utils
+
+
+def _match_f_string(f_string: str, string: str) -> bool:
+    pattern = re.sub(r"{[^{}]*}", "(.*)", f_string)
+    return bool(re.fullmatch(pattern, string))
 
 
 class Provider(provider.Provider):
-    def __init__(self):
-        self._functions, self._collections = loader.load_functions_collections()
+    def __init__(
+        self,
+        filter_rapidapi_api_hostnames: list[str] | str | None = None,
+        filter_rapidapi_endpoint_urls: list[str] | str | None = None,
+    ):
+        functions, collections = loader.load_functions_collections()
+
+        if isinstance(filter_rapidapi_api_hostnames, str):
+            filter_rapidapi_api_hostnames = [filter_rapidapi_api_hostnames]
+        if isinstance(filter_rapidapi_endpoint_urls, str):
+            filter_rapidapi_endpoint_urls = [filter_rapidapi_endpoint_urls]
+
+        rapidapi_api_hostnames = None
+        if filter_rapidapi_api_hostnames:
+            rapidapi_api_hostnames = {
+                rapidapi_utils.url_hostname(url)
+                for url in filter_rapidapi_api_hostnames
+            }
+
+        rapidapi_hostname_to_function_urls = None
+        if filter_rapidapi_endpoint_urls:
+            rapidapi_hostname_to_function_urls = defaultdict(list)
+            for url in (
+                rapidapi_utils.sanitize_url(url)
+                for url in filter_rapidapi_endpoint_urls
+            ):
+                rapidapi_hostname_to_function_urls[
+                    rapidapi_utils.url_hostname(url)
+                ].append(url)
+
+        name_to_fn = {
+            fn.spec.name: fn
+            for fn in functions
+            if (
+                not (filter_rapidapi_api_hostnames or filter_rapidapi_endpoint_urls)
+                or (
+                    rapidapi_api_hostnames
+                    and isinstance(fn, rapidapi_function.RapidAPIFunction)
+                    and (fn.root_url in rapidapi_api_hostnames)
+                )
+                or (
+                    rapidapi_hostname_to_function_urls
+                    and isinstance(fn, rapidapi_function.RapidAPIFunction)
+                    and (
+                        urls := rapidapi_hostname_to_function_urls.get(fn.root_url, [])
+                    )
+                    and any(_match_f_string(fn.url_f_string, url) for url in urls)
+                )
+            )
+        }
+
+        self._functions = list(name_to_fn.values())
+        self._collections = [
+            c
+            for c in (
+                function.FunctionCollection(
+                    name=c.name,
+                    description=c.description,
+                    function_names=(c.function_names & name_to_fn.keys()),
+                )
+                for c in collections
+            )
+            if c.function_names
+        ]
 
     def functions(self) -> list[function.Function]:
         return self._functions
@@ -17,5 +89,12 @@ class Provider(provider.Provider):
         return self._collections
 
     @classmethod
-    def standard(cls) -> Provider:
-        return cls()
+    def standard(
+        cls,
+        filter_rapidapi_api_hostnames: list[str] | str | None = None,
+        filter_rapidapi_endpoint_urls: list[str] | str | None = None,
+    ) -> Provider:
+        return cls(
+            filter_rapidapi_api_hostnames=filter_rapidapi_api_hostnames,
+            filter_rapidapi_endpoint_urls=filter_rapidapi_endpoint_urls,
+        )

--- a/toolhub/lib/auth.py
+++ b/toolhub/lib/auth.py
@@ -33,20 +33,20 @@ class StandardAuthContext(AuthContext):
     @classmethod
     def from_settings(cls) -> AuthContext:
         openapi = None
-        if settings.auth.openapi:
+        if oa := settings.auth.get("openapi"):
             openapi = OpenApiAuthContext(
                 api_to_headers={
                     api: headers
-                    for api, headers in settings.auth.openapi.api_to_headers.items()
+                    for api, headers in (oa.get("api_to_headers") or {}).items()
                 },
             )
         rapidapi = None
-        if settings.auth.rapidapi:
+        if ra := settings.auth.get("rapidapi"):
             rapidapi = RapidApiAuthContext(
-                rapidapi_key=settings.auth.rapidapi.rapidapi_key,
+                rapidapi_key=ra.rapidapi_key,
                 host_to_headers={
                     name: headers
-                    for name, headers in settings.auth.rapidapi.host_to_headers.items()
+                    for name, headers in (ra.get("host_to_headers") or {}).items()
                 },
             )
         return StandardAuthContext(openapi=openapi, rapidapi=rapidapi)

--- a/toolhub/lib/registry.py
+++ b/toolhub/lib/registry.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
-
-from collections import defaultdict
 import re
 from typing import Any, Generic, TypeVar
 
 from toolhub.lib import auth
 from toolhub.lib import function
 from toolhub.lib import provider
-from toolhub.integrations.openapi import provider as openapi_provider
-from toolhub.integrations.rapidapi import provider as rapidapi_provider
-from toolhub.integrations.rapidapi import function as rapidapi_function
-from toolhub.integrations.rapidapi import utils as rapidapi_utils
-from toolhub.standard_providers import random_provider
 
 ToolName = str
 AuthContext = TypeVar("AuthContext", bound=auth.AuthContext)
@@ -30,8 +23,6 @@ class Registry(Generic[AuthContext]):
         self,
         providers: list[provider.Provider],
         filter_collections: list[str] | str | None = None,
-        filter_rapidapi_api_hostnames: list[str] | str | None = None,
-        filter_rapidapi_endpoint_urls: list[str] | str | None = None,
     ):
         functions = {
             fn.spec.name: fn for provider in providers for fn in provider.functions()
@@ -42,79 +33,24 @@ class Registry(Generic[AuthContext]):
 
         if isinstance(filter_collections, str):
             filter_collections = [filter_collections]
-        if isinstance(filter_rapidapi_api_hostnames, str):
-            filter_rapidapi_api_hostnames = [filter_rapidapi_api_hostnames]
-        if isinstance(filter_rapidapi_endpoint_urls, str):
-            filter_rapidapi_endpoint_urls = [filter_rapidapi_endpoint_urls]
 
-        name_to_fn = {}
-
-        rapidapi_api_hostnames = set()
-        if filter_rapidapi_api_hostnames:
-            rapidapi_api_hostnames = {
-                rapidapi_utils.url_hostname(url)
-                for url in filter_rapidapi_api_hostnames
-            }
-
-        rapidapi_hostname_to_function_urls: dict[str, list[str]] = defaultdict(list)
-        if filter_rapidapi_endpoint_urls:
-            for url in (
-                rapidapi_utils.sanitize_url(url)
-                for url in filter_rapidapi_endpoint_urls
-            ):
-                rapidapi_hostname_to_function_urls[
-                    rapidapi_utils.url_hostname(url)
-                ].append(url)
-
-        for fn_name, fn in functions.items():
-            if not (
-                filter_collections
-                or rapidapi_api_hostnames
-                or rapidapi_hostname_to_function_urls
-            ):
-                name_to_fn[fn_name] = fn
-            elif filter_collections and any(
-                (fn_name in collections[collection_name].function_names)
-                for collection_name in filter_collections
-            ):
-                name_to_fn[fn_name] = fn
-            elif (
-                rapidapi_api_hostnames
-                and isinstance(fn, rapidapi_function.RapidAPIFunction)
-                and (fn.root_url in rapidapi_api_hostnames)
-            ):
-                name_to_fn[fn_name] = fn
-            elif (
-                rapidapi_hostname_to_function_urls
-                and isinstance(fn, rapidapi_function.RapidAPIFunction)
-                and (urls := rapidapi_hostname_to_function_urls.get(fn.root_url, []))
-                and any(_match_f_string(fn.url_f_string, url) for url in urls)
-            ):
-                name_to_fn[fn_name] = fn
-            self._name_to_fn = name_to_fn
+        self._name_to_fn = {
+            fn_name: fn
+            for fn_name, fn in functions.items()
+            if (
+                not filter_collections
+                or (
+                    filter_collections
+                    and any(
+                        (fn_name in collections[collection_name].function_names)
+                        for collection_name in filter_collections
+                    )
+                )
+            )
+        }
 
     def list_(self) -> list[function.Function[Any, Any, AuthContext]]:
         return list(self._name_to_fn.values())
 
     def get(self, name: ToolName) -> function.Function[Any, Any, AuthContext]:
         return self._name_to_fn[name]
-
-    @classmethod
-    def standard(
-        cls,
-        openapi: openapi_provider.Provider | None = None,
-        rapidapi: rapidapi_provider.Provider | None = None,
-        filter_collections: list[str] | None = None,
-        filter_rapidapi_api_hostnames: list[str] | None = None,
-        filter_rapidapi_endpoint_urls: list[str] | None = None,
-    ) -> Registry:
-        return cls(
-            [
-                random_provider.Provider(),
-                openapi or openapi_provider.Provider.standard(),
-                rapidapi or rapidapi_provider.Provider.standard(),
-            ],
-            filter_collections=filter_collections,
-            filter_rapidapi_api_hostnames=filter_rapidapi_api_hostnames,
-            filter_rapidapi_endpoint_urls=filter_rapidapi_endpoint_urls,
-        )


### PR DESCRIPTION
Clients that don't use OpenAPI or RapidAPI shouldn't have to import them.